### PR TITLE
Fix projection with earlybound

### DIFF
--- a/src/Digitall.Stub/Extensions/Extensions.cs
+++ b/src/Digitall.Stub/Extensions/Extensions.cs
@@ -104,8 +104,9 @@ public static class Extensions
         }
 
         //Return selected list of attributes in a projected entity
-        var projected = new Entity(e.LogicalName) { Id = e.Id };
-
+        var projected = Activator.CreateInstance(e.GetType()) as Entity;
+        projected.LogicalName = e.LogicalName;
+        projected.Id = e.Id;
 
         foreach (var attKey in qe.ColumnSet.Columns)
         {

--- a/tests/Digitall.Stub.Tests/OrganizationRequests/DataContextTests.cs
+++ b/tests/Digitall.Stub.Tests/OrganizationRequests/DataContextTests.cs
@@ -2,6 +2,7 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using System;
+using System.Linq;
 using Digitall.Stub.Tests.Fixtures;
 using FluentAssertions;
 
@@ -33,6 +34,40 @@ public class DataContextTests
         using (var dataContext = new DataContext(stub))
         {
             dataContext.AccountSet.Should().NotBeEmpty();
+        }
+    }
+
+    [TestMethod]
+    public void ProjectionOfEarlyBound_Should_MaintainType()
+    {
+        var stub = new DataverseStub();
+        stub.AddDefaultStubs();
+
+        var accountId = Guid.NewGuid();
+        var accountName = "Test Account";
+        var account = new Account(accountId)
+        {
+            Name = accountName,
+        };
+        stub.Add(account);
+
+        using (var dataContext = new DataContext(stub))
+        {
+            dataContext.AccountSet.Select(a => a.Id).Single().Should().Be(accountId);
+        }
+
+        using (var dataContext = new DataContext(stub))
+        {
+            dataContext.AccountSet.Select(a => a.Name).Single().Should().Be(accountName);
+        }
+
+        account.Id.Should().Be(accountId);
+        account.Name.Should().Be(accountName);
+
+        using (var dataContext = new DataContext(stub))
+        {
+            dataContext.AccountSet.Select(a => a.Id).Single().Should().Be(accountId);
+            dataContext.AccountSet.Select(a => a.Name).Single().Should().Be(accountName);
         }
     }
 }

--- a/tests/Digitall.Stub.Tests/OrganizationRequests/DataContextTests.cs
+++ b/tests/Digitall.Stub.Tests/OrganizationRequests/DataContextTests.cs
@@ -66,7 +66,6 @@ public class DataContextTests
 
         using (var dataContext = new DataContext(stub))
         {
-            dataContext.AccountSet.Select(a => a.Id).Single().Should().Be(accountId);
             dataContext.AccountSet.Select(a => a.Name).Single().Should().Be(accountName);
         }
     }


### PR DESCRIPTION
Projection from datacontext fails with error:
 `Object of type 'Microsoft.Xrm.Sdk.Entity' cannot be converted to type`

Proposed fix creates new entity that respects known type by creating it dynamically through the `Activator`.

Todos:
- [x] Fix failing test