### PR TITLE
feat: allow registration of additional services in IServiceProvider

### DIFF
--- a/src/Digitall.Testing/FakePluginContextBuilder.cs
+++ b/src/Digitall.Testing/FakePluginContextBuilder.cs
@@ -10,6 +10,8 @@ namespace Digitall.Testing;
 /// </summary>
 public class FakePluginContextBuilder : PluginExecutionContextBuilder, IFakeDataverseBuilder<FakeOrganizationService>
 {
+    private readonly TimeProvider _timeProvider;
+
     /// <summary>
     /// Creates a new instance of <see cref="FakePluginContextBuilder"/> with a default <see cref="FakeOrganizationService"/>.
     /// </summary>
@@ -23,6 +25,7 @@ public class FakePluginContextBuilder : PluginExecutionContextBuilder, IFakeData
     /// </summary>
     public FakePluginContextBuilder(TimeProvider timeProvider) : base(ConfigureOrganizationService(timeProvider))
     {
+        _timeProvider = timeProvider;
     }
 
     /// <summary>
@@ -30,6 +33,7 @@ public class FakePluginContextBuilder : PluginExecutionContextBuilder, IFakeData
     /// </summary>
     public FakePluginContextBuilder(FakeOrganizationService organizationService) : base(organizationService)
     {
+        _timeProvider = organizationService.TimeProvider;
     }
 
     /// <summary>
@@ -37,6 +41,11 @@ public class FakePluginContextBuilder : PluginExecutionContextBuilder, IFakeData
     /// </summary>
     public FakeOrganizationService GetOrganizationService() =>
         OrganizationService as FakeOrganizationService ?? throw new InvalidOperationException("OrganizationService is not a FakeOrganizationService.");
+
+    protected override Dictionary<Type, object> AdditionalServices => new()
+    {
+        [typeof(TimeProvider)] = _timeProvider
+    };
 
     private static FakeOrganizationService ConfigureOrganizationService(TimeProvider timeProvider)
     {

--- a/src/Digitall.Testing/FakePluginContextBuilder.cs
+++ b/src/Digitall.Testing/FakePluginContextBuilder.cs
@@ -42,10 +42,11 @@ public class FakePluginContextBuilder : PluginExecutionContextBuilder, IFakeData
     public FakeOrganizationService GetOrganizationService() =>
         OrganizationService as FakeOrganizationService ?? throw new InvalidOperationException("OrganizationService is not a FakeOrganizationService.");
 
-    protected override Dictionary<Type, object> AdditionalServices => new()
+    protected override void ConfigureServices(IServiceProviderMock serviceProvider)
     {
-        [typeof(TimeProvider)] = _timeProvider
-    };
+        base.ConfigureServices(serviceProvider);
+        serviceProvider.GetService(typeof(TimeProvider)).Returns(_timeProvider);
+    }
 
     private static FakeOrganizationService ConfigureOrganizationService(TimeProvider timeProvider)
     {

--- a/src/Digitall.Testing/PluginExecutionContextBuilder.cs
+++ b/src/Digitall.Testing/PluginExecutionContextBuilder.cs
@@ -71,10 +71,12 @@ public class PluginExecutionContextBuilder
     public ILogger Logger { get; set; } = ILogger.Mock();
 
     /// <summary>
-    /// Additional services to register in the mock <see cref="IServiceProvider"/>.
-    /// Override in subclasses to register custom services.
+    /// Override this method to add additional service mocks to the <see cref="IServiceProvider"/>.
     /// </summary>
-    protected virtual Dictionary<Type, object> AdditionalServices => new();
+    /// <param name="serviceProvider">The service provider.</param>
+    protected virtual void ConfigureServices(IServiceProviderMock serviceProvider)
+    {
+    }
 
     public IServiceProvider BuildServiceProvider()
     {
@@ -128,10 +130,7 @@ public class PluginExecutionContextBuilder
         serviceProvider.GetService(typeof(ITracingService)).Returns(TracingService);
         serviceProvider.GetService(typeof(ILogger)).Returns(Logger);
 
-        foreach (var (type, instance) in AdditionalServices)
-        {
-            serviceProvider.GetService(type).Returns(instance);
-        }
+        ConfigureServices(serviceProvider);
 
         return serviceProvider;
     }

--- a/src/Digitall.Testing/PluginExecutionContextBuilder.cs
+++ b/src/Digitall.Testing/PluginExecutionContextBuilder.cs
@@ -70,6 +70,12 @@ public class PluginExecutionContextBuilder
     public ITracingService TracingService { get; set; } = ITracingService.Mock();
     public ILogger Logger { get; set; } = ILogger.Mock();
 
+    /// <summary>
+    /// Additional services to register in the mock <see cref="IServiceProvider"/>.
+    /// Override in subclasses to register custom services.
+    /// </summary>
+    protected virtual Dictionary<Type, object> AdditionalServices => new();
+
     public IServiceProvider BuildServiceProvider()
     {
         var pluginExecutionContext = IPluginExecutionContext7.Mock();
@@ -121,6 +127,11 @@ public class PluginExecutionContextBuilder
         serviceProvider.GetService(typeof(IOrganizationServiceFactory)).Returns(organizationServiceFactory);
         serviceProvider.GetService(typeof(ITracingService)).Returns(TracingService);
         serviceProvider.GetService(typeof(ILogger)).Returns(Logger);
+
+        foreach (var (type, instance) in AdditionalServices)
+        {
+            serviceProvider.GetService(type).Returns(instance);
+        }
 
         return serviceProvider;
     }


### PR DESCRIPTION
expose extension point to PluginExecutionContextBuilder to add additional services in fake builders deriving from it while keeping the default behavior untouched