### PR TITLE
fix(builder): make UserId settable agnostically without mutating env …

### DIFF
--- a/src/Digitall.Testing/Extensions/PluginExecutionContextBuilderExtensions.cs
+++ b/src/Digitall.Testing/Extensions/PluginExecutionContextBuilderExtensions.cs
@@ -89,6 +89,12 @@ public static class PluginExecutionContextBuilderExtensions
             return builder;
         }
 
+        public TPluginExecutionContextBuilder WithUserId(Guid userId)
+        {
+            builder.UserId = userId;
+            return builder;
+        }
+
         public TPluginExecutionContextBuilder WithCorrelationId(Guid correlationId)
         {
             builder.CorrelationId = correlationId;

--- a/src/Digitall.Testing/PluginExecutionContextBuilder.cs
+++ b/src/Digitall.Testing/PluginExecutionContextBuilder.cs
@@ -54,15 +54,20 @@ public class PluginExecutionContextBuilder
     public ParameterCollection SharedVariables { get; set; } = [];
     public Guid InitiatingUserId { get; set; }
 
-    public static Guid UserId
+    private Guid? _userId;
+
+    public Guid UserId
     {
         get
         {
+            if (_userId.HasValue)
+                return _userId.Value;
+
             Guid.TryParse(Environment.GetEnvironmentVariable("UserId"), out var userId);
             return userId;
         }
         // ReSharper disable once UnusedMember.Global : Public API
-        set { Environment.SetEnvironmentVariable("UserId", value.ToString()); }
+        set => _userId = value;
     }
 
     public Guid CorrelationId { get; set; } = Guid.NewGuid();

--- a/tests/Digitall.Testing.Tests/Extensions/PluginExecutionContextBuilderExtensionsTests.cs
+++ b/tests/Digitall.Testing.Tests/Extensions/PluginExecutionContextBuilderExtensionsTests.cs
@@ -218,6 +218,59 @@ public class PluginExecutionContextBuilderExtensionsTests
     }
 
     [Test]
+    public async Task WithUserId_ShouldSetUserIdAndReturnSameBuilder()
+    {
+        var userId = Guid.NewGuid();
+        var builder = new PluginExecutionContextBuilder();
+
+        var result = builder.WithUserId(userId);
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(builder.UserId).IsEqualTo(userId);
+    }
+
+    [Test]
+    public async Task WithUserId_ShouldTakePrecedenceOverEnvVariable()
+    {
+        var originalUserId = Environment.GetEnvironmentVariable("UserId");
+        var explicitUserId = Guid.NewGuid();
+        var envUserId = Guid.NewGuid();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("UserId", envUserId.ToString());
+
+            var builder = new PluginExecutionContextBuilder().WithUserId(explicitUserId);
+
+            await Assert.That(builder.UserId).IsEqualTo(explicitUserId);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("UserId", originalUserId);
+        }
+    }
+
+    [Test]
+    public async Task WithUserId_ShouldNotModifyEnvironmentVariable()
+    {
+        var originalUserId = Environment.GetEnvironmentVariable("UserId");
+        var explicitUserId = Guid.NewGuid();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("UserId", null);
+
+            new PluginExecutionContextBuilder().WithUserId(explicitUserId);
+
+            await Assert.That(Environment.GetEnvironmentVariable("UserId")).IsNull();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("UserId", originalUserId);
+        }
+    }
+
+    [Test]
     public async Task WithCorrelationId_ShouldSetCorrelationIdAndReturnSameBuilder()
     {
         var correlationId = Guid.NewGuid();
@@ -317,6 +370,7 @@ public class PluginExecutionContextBuilderExtensionsTests
         var entityTarget = new Entity("account", Guid.NewGuid());
         var preImage = new Entity("account", Guid.NewGuid());
         var postImage = new Entity("account", Guid.NewGuid());
+        var userId = Guid.NewGuid();
         var initiatingUserId = Guid.NewGuid();
         var correlationId = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
@@ -331,6 +385,7 @@ public class PluginExecutionContextBuilderExtensionsTests
             .WithInputParameter("in", 1)
             .WithOutputParameter("out", 2)
             .WithSharedVariable("shared", 3)
+            .WithUserId(userId)
             .WithInitiatingUserId(initiatingUserId)
             .WithCorrelationId(correlationId)
             .WithMessageName("Create")
@@ -346,6 +401,7 @@ public class PluginExecutionContextBuilderExtensionsTests
         await Assert.That(builder.InputParameters.ContainsKey("in")).IsTrue();
         await Assert.That(builder.OutputParameters.ContainsKey("out")).IsTrue();
         await Assert.That(builder.SharedVariables.ContainsKey("shared")).IsTrue();
+        await Assert.That(builder.UserId).IsEqualTo(userId);
         await Assert.That(builder.InitiatingUserId).IsEqualTo(initiatingUserId);
         await Assert.That(builder.CorrelationId).IsEqualTo(correlationId);
         await Assert.That(builder.MessageName).IsEqualTo("Create");

--- a/tests/Digitall.Testing.Tests/PluginExecutionContextBuilderTests.cs
+++ b/tests/Digitall.Testing.Tests/PluginExecutionContextBuilderTests.cs
@@ -298,6 +298,28 @@ public class PluginExecutionContextBuilderTests
     }
 
     [Test]
+    public async Task UserId_WhenEnvVariableSet_Should_BeUsedAsDefault()
+    {
+        var originalUserId = Environment.GetEnvironmentVariable("UserId");
+        var envUserId = Guid.NewGuid();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("UserId", envUserId.ToString());
+
+            var serviceProvider = new PluginExecutionContextBuilder().BuildServiceProvider();
+            var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
+
+            await Assert.That(pluginContext).IsNotNull();
+            await Assert.That(pluginContext!.UserId).IsEqualTo(envUserId);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("UserId", originalUserId);
+        }
+    }
+
+    [Test]
     public async Task InvalidUserIdEnvVar_Should_DefaultToEmptyGuid()
     {
         var originalUserId = Environment.GetEnvironmentVariable("UserId");


### PR DESCRIPTION
…variable

UserId previously wrote directly to the environment variable on set, making it impossible for consumers to override the value in isolation. The env variable now acts only as a default fallback when no explicit value has been set via the property or WithUserId().