### PR TITLE
feat: use Options class for explicit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,11 @@ var service = new FakeDataverseBuilder()
 - `.AddEntityMetadata(params EntityMetadata[])` — register entity metadata
 - `.AddRelationships(params RelationshipMetadataBase[])` — register relationships
 - `.LoadMetadata(string path)` — load `EntityMetadata` from XML (file or directory)
-- `.AddConfig(key, envVar, defaultValue)` — configure environment variables
+- `.AddConfig(key, defaultValue, value?)` — add Dataverse environment variable definition/value entities
+- `.WithUserId(Guid)` — set the current user ID
+- `.WithBusinessUnitId(Guid)` — set the current business unit ID
+- `.WithMaxRetrieveCount(int)` — set the max records per page
+- `.WithFiscalYearStart(DateOnly)` — set the fiscal year start date
 
 ### PluginExecutionContextBuilder
 
@@ -550,21 +554,32 @@ fakeTime.Advance(TimeSpan.FromDays(30));
 
 ## Configuration
 
-The `FakeOrganizationService` uses environment variables for configurable behavior:
+The `FakeOrganizationService` exposes a `FakeDataverseOptions` instance via the `Options` property for per-test configuration. This avoids process-global state (such as environment variables) and is safe for parallel test execution.
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MaxRetrieveCount` | Maximum records returned by `RetrieveMultiple` | `5000` |
-| `UserId` | Current user ID (used in `WhoAmI` and `EqualUserId` filters) | `Guid.Empty` |
-| `BusinessUnitId` | Current business unit ID | `Guid.Empty` |
-| `FiscalYearStart` | Start date for fiscal year calculations | Current year start |
+| Option | Type | Description | Default |
+|--------|------|-------------|---------|
+| `UserId` | `Guid` | Current user ID (used in `WhoAmI`, `EqualUserId` filters, and default record ownership) | `Guid.Empty` |
+| `BusinessUnitId` | `Guid` | Current business unit ID (used in `WhoAmI` and `EqualBusinessId` filters) | `Guid.Empty` |
+| `FiscalYearStart` | `DateOnly?` | Start date for fiscal year calculations | `null` (defaults to Jan 1) |
+| `MaxRetrieveCount` | `int` | Maximum records returned by `RetrieveMultiple` per page | `5000` |
 
 Configure via the builder:
 
 ```csharp
 var service = new FakeDataverseBuilder()
-    .AddConfig("MaxRetrieveCount", "5000", "1000")
+    .WithUserId(userId)
+    .WithBusinessUnitId(businessUnitId)
+    .WithMaxRetrieveCount(100)
+    .WithFiscalYearStart(new DateOnly(2025, 4, 1))
     .GetOrganizationService();
+```
+
+Or set directly on the service:
+
+```csharp
+var service = new FakeOrganizationService();
+service.Options.UserId = userId;
+service.Options.MaxRetrieveCount = 100;
 ```
 
 ---
@@ -577,6 +592,7 @@ DigitallTesting/
 │   ├── FakeOrganizationService.cs              # IOrganizationService implementation
 │   ├── FakeOrganizationServiceAsync.cs         # IOrganizationServiceAsync2 implementation
 │   ├── FakeOrganizationServiceState.cs         # Internal entity store
+│   ├── FakeDataverseOptions.cs                 # Per-instance configuration options
 │   ├── FakeDataverseBuilder.cs                 # Fluent builder for service setup
 │   ├── FakePluginContextBuilder.cs             # Combined plugin + service builder
 │   ├── IFakeDataverseBuilder.cs                # Builder interface

--- a/src/Digitall.Dataverse.Testing/Extensions/FakeDataverseBuilderExtensions.cs
+++ b/src/Digitall.Dataverse.Testing/Extensions/FakeDataverseBuilderExtensions.cs
@@ -89,6 +89,7 @@ public static class FakeDataverseBuilderExtensions
 
         public TBuilder WithMaxRetrieveCount(int maxRetrieveCount)
         {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxRetrieveCount);
             var service = builder.GetOrganizationService();
             service.Options.MaxRetrieveCount = maxRetrieveCount;
             return builder;

--- a/src/Digitall.Dataverse.Testing/Extensions/FakeDataverseBuilderExtensions.cs
+++ b/src/Digitall.Dataverse.Testing/Extensions/FakeDataverseBuilderExtensions.cs
@@ -66,6 +66,34 @@ public static class FakeDataverseBuilderExtensions
             return builder;
         }
 
+        public TBuilder WithUserId(Guid userId)
+        {
+            var service = builder.GetOrganizationService();
+            service.Options.UserId = userId;
+            return builder;
+        }
+
+        public TBuilder WithBusinessUnitId(Guid businessUnitId)
+        {
+            var service = builder.GetOrganizationService();
+            service.Options.BusinessUnitId = businessUnitId;
+            return builder;
+        }
+
+        public TBuilder WithFiscalYearStart(DateOnly fiscalYearStart)
+        {
+            var service = builder.GetOrganizationService();
+            service.Options.FiscalYearStart = fiscalYearStart;
+            return builder;
+        }
+
+        public TBuilder WithMaxRetrieveCount(int maxRetrieveCount)
+        {
+            var service = builder.GetOrganizationService();
+            service.Options.MaxRetrieveCount = maxRetrieveCount;
+            return builder;
+        }
+
         /// <summary>
         /// Adds an environment variable configuration entry to the builder's organization service.
         /// Optionally adds a value override on top of the default.

--- a/src/Digitall.Dataverse.Testing/FakeDataverseOptions.cs
+++ b/src/Digitall.Dataverse.Testing/FakeDataverseOptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) DIGITALL Nature. All rights reserved
+// DIGITALL Nature licenses this file to you under the Microsoft Public License.
+
+namespace Digitall.Dataverse.Testing;
+
+public class FakeDataverseOptions
+{
+    public Guid UserId { get; set; } = Guid.Empty;
+    public Guid BusinessUnitId { get; set; } = Guid.Empty;
+    public DateOnly? FiscalYearStart { get; set; }
+    public int MaxRetrieveCount { get; set; } = 5000;
+}

--- a/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
+++ b/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
@@ -322,7 +322,10 @@ public class FakeOrganizationService(TimeProvider timeProvider, FakeOrganization
             var isOrganizationOwned = State.EntityMetadata.TryGetValue(clone.LogicalName, out var metadata)
                                       && metadata.OwnershipType == OwnershipTypes.OrganizationOwned;
 
-            if (!isOrganizationOwned && Options.UserId != Guid.Empty)
+            var entityTypeIsKnown = EntityTypeIsKnown(clone.LogicalName, out _);
+            var ownerIdExistsOnType = IsKnownAttributeForType(clone.LogicalName, "ownerid", out _);
+
+            if (!isOrganizationOwned && Options.UserId != Guid.Empty && (!entityTypeIsKnown || ownerIdExistsOnType))
             {
                 clone["ownerid"] = new EntityReference("systemuser", Options.UserId);
             }

--- a/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
+++ b/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
@@ -16,7 +16,8 @@ namespace Digitall.Dataverse.Testing;
 
 public class FakeOrganizationService(TimeProvider timeProvider, FakeOrganizationServiceState state) : IOrganizationService
 {
-    public readonly TimeProvider TimeProvider = timeProvider;
+    public TimeProvider TimeProvider { get; } = timeProvider;
+    public FakeDataverseOptions Options { get; } = new();
 
     public FakeOrganizationServiceState State { get; } = state;
 
@@ -313,6 +314,18 @@ public class FakeOrganizationService(TimeProvider timeProvider, FakeOrganization
         {
             var resolvedStatecode = clone.GetAttributeValue<OptionSetValue>("statecode");
             clone["statuscode"] = State.GetDefaultStatusCode(clone.LogicalName, resolvedStatecode.Value);
+        }
+
+        // Default ownerid for user-owned entities
+        if (!clone.Contains("ownerid"))
+        {
+            var isOrganizationOwned = State.EntityMetadata.TryGetValue(clone.LogicalName, out var metadata)
+                                      && metadata.OwnershipType == OwnershipTypes.OrganizationOwned;
+
+            if (!isOrganizationOwned && Options.UserId != Guid.Empty)
+            {
+                clone["ownerid"] = new EntityReference("systemuser", Options.UserId);
+            }
         }
 
         try

--- a/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
+++ b/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
@@ -373,7 +373,18 @@ public class FakeOrganizationService(TimeProvider timeProvider, FakeOrganization
             ErrorFactory.ThrowFault(ErrorCodes.ObjectDoesNotExist, $"Entity '{entity.LogicalName}' With Id = {entity.Id:D} Does Not Exist");
         }
 
-        value[entity.Id] = entity.CloneEntity();
+        var merged = value[entity.Id].CloneEntity();
+
+        foreach (var attr in entity.Attributes)
+            merged.Attributes[attr.Key] = attr.Value;
+
+        foreach (var fv in entity.FormattedValues)
+            merged.FormattedValues[fv.Key] = fv.Value;
+
+        foreach (var ka in entity.KeyAttributes)
+            merged.KeyAttributes[ka.Key] = ka.Value;
+
+        value[entity.Id] = merged;
     }
 
     public void Delete(string? entityName, Guid id)

--- a/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
+++ b/src/Digitall.Dataverse.Testing/FakeOrganizationService.cs
@@ -328,6 +328,19 @@ public class FakeOrganizationService(TimeProvider timeProvider, FakeOrganization
             }
         }
 
+        var now = TimeProvider.GetUtcNow().UtcDateTime;
+        if (!clone.Contains("createdon"))  clone["createdon"]  = now;
+        if (!clone.Contains("modifiedon")) clone["modifiedon"] = now;
+
+        if (Options.UserId != Guid.Empty)
+        {
+            var userRef = new EntityReference("systemuser", Options.UserId);
+            if (!clone.Contains("createdby"))  clone["createdby"]  = userRef;
+            if (!clone.Contains("modifiedby")) clone["modifiedby"] = userRef;
+        }
+
+        clone.RowVersion ??= TimeProvider.GetUtcNow().Ticks.ToString();
+
         try
         {
             Add(clone);
@@ -383,6 +396,14 @@ public class FakeOrganizationService(TimeProvider timeProvider, FakeOrganization
 
         foreach (var ka in entity.KeyAttributes)
             merged.KeyAttributes[ka.Key] = ka.Value;
+
+        foreach (var re in entity.RelatedEntities)
+            merged.RelatedEntities[re.Key] = re.Value;
+
+        merged["modifiedon"] = TimeProvider.GetUtcNow().UtcDateTime;
+        if (Options.UserId != Guid.Empty)
+            merged["modifiedby"] = new EntityReference("systemuser", Options.UserId);
+        merged.RowVersion = TimeProvider.GetUtcNow().Ticks.ToString();
 
         value[entity.Id] = merged;
     }

--- a/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
+++ b/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
@@ -99,7 +99,7 @@ public static class ConditionParser
         throw new FaultException(faultReason);
     }
 
-    public static Expression TranslateConditionExpression(QueryExpression queryExpression, FakeOrganizationService context, TypedConditionExpression condition, ParameterExpression entity)
+    public static Expression TranslateConditionExpression(QueryExpression queryExpression, FakeOrganizationService organizationService, TypedConditionExpression condition, ParameterExpression entity)
     {
         Expression attributesProperty = Expression.Property(entity, "Attributes");
 
@@ -136,14 +136,14 @@ public static class ConditionParser
             case ConditionOperator.Tomorrow:
             case ConditionOperator.EqualUserId:
             case ConditionOperator.EqualBusinessId:
-                operatorExpression = TranslateConditionExpressionEqual(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
+                operatorExpression = TranslateConditionExpressionEqual(organizationService, condition, getAttributeValueExpr, containsAttributeExpression);
                 break;
 
             case ConditionOperator.NotOn:
             case ConditionOperator.NotEqual:
             case ConditionOperator.NotEqualUserId:
             case ConditionOperator.NotEqualBusinessId:
-                operatorExpression = Expression.Not(TranslateConditionExpressionEqual(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression));
+                operatorExpression = Expression.Not(TranslateConditionExpressionEqual(organizationService, condition, getAttributeValueExpr, containsAttributeExpression));
                 break;
 
             #endregion
@@ -196,7 +196,7 @@ public static class ConditionParser
                 break;
 
             case ConditionOperator.GreaterEqual:
-                operatorExpression = TranslateConditionExpressionGreaterThanOrEqual(context, condition, getAttributeValueExpr, containsAttributeExpression);
+                operatorExpression = TranslateConditionExpressionGreaterThanOrEqual(organizationService, condition, getAttributeValueExpr, containsAttributeExpression);
                 break;
 
             case ConditionOperator.LessThan:
@@ -204,7 +204,7 @@ public static class ConditionParser
                 break;
 
             case ConditionOperator.LessEqual:
-                operatorExpression = TranslateConditionExpressionLessThanOrEqual(context, condition, getAttributeValueExpr, containsAttributeExpression);
+                operatorExpression = TranslateConditionExpressionLessThanOrEqual(organizationService, condition, getAttributeValueExpr, containsAttributeExpression);
                 break;
 
             #endregion
@@ -232,7 +232,7 @@ public static class ConditionParser
             #region Time Operations
 
             case ConditionOperator.OnOrAfter:
-                operatorExpression = Expression.Or(TranslateConditionExpressionEqual(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression),
+                operatorExpression = Expression.Or(TranslateConditionExpressionEqual(organizationService, condition, getAttributeValueExpr, containsAttributeExpression),
                     TranslateConditionExpressionGreaterThan(condition, getAttributeValueExpr, containsAttributeExpression));
                 break;
             case ConditionOperator.LastXHours:
@@ -241,11 +241,11 @@ public static class ConditionParser
             case ConditionOperator.LastXWeeks:
             case ConditionOperator.LastXMonths:
             case ConditionOperator.LastXYears:
-                operatorExpression = TranslateConditionExpressionLast(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
+                operatorExpression = TranslateConditionExpressionLast(organizationService.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
                 break;
 
             case ConditionOperator.OnOrBefore:
-                operatorExpression = Expression.Or(TranslateConditionExpressionEqual(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression),
+                operatorExpression = Expression.Or(TranslateConditionExpressionEqual(organizationService, condition, getAttributeValueExpr, containsAttributeExpression),
                     TranslateConditionExpressionLessThan(condition, getAttributeValueExpr, containsAttributeExpression));
                 break;
 
@@ -272,7 +272,7 @@ public static class ConditionParser
             case ConditionOperator.OlderThanXWeeks:
             case ConditionOperator.OlderThanXYears:
             case ConditionOperator.OlderThanXMonths:
-                operatorExpression = TranslateConditionExpressionOlderThan(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
+                operatorExpression = TranslateConditionExpressionOlderThan(organizationService.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
                 break;
 
             case ConditionOperator.NextXHours:
@@ -281,7 +281,7 @@ public static class ConditionParser
             case ConditionOperator.NextXWeeks:
             case ConditionOperator.NextXMonths:
             case ConditionOperator.NextXYears:
-                operatorExpression = TranslateConditionExpressionNext(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
+                operatorExpression = TranslateConditionExpressionNext(organizationService.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
                 break;
             case ConditionOperator.ThisYear:
             case ConditionOperator.LastYear:
@@ -293,7 +293,7 @@ public static class ConditionParser
             case ConditionOperator.ThisWeek:
             case ConditionOperator.NextWeek:
             case ConditionOperator.InFiscalYear:
-                operatorExpression = TranslateConditionExpressionBetweenDates(context.TimeProvider, condition, getAttributeValueExpr, containsAttributeExpression);
+                operatorExpression = TranslateConditionExpressionBetweenDates(organizationService, condition, getAttributeValueExpr, containsAttributeExpression);
                 break;
 
             #endregion
@@ -375,14 +375,14 @@ public static class ConditionParser
     /// <summary>
     ///     Takes a condition expression which needs translating into a 'between two dates' expression and works out the relevant dates
     /// </summary>
-    private static BinaryExpression TranslateConditionExpressionBetweenDates(TimeProvider timeProvider, TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr)
+    private static BinaryExpression TranslateConditionExpressionBetweenDates(FakeOrganizationService organizationService, TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr)
     {
         var c = tc.CondExpression;
 
         DateTime? fromDate = null;
         DateTime? toDate = null;
 
-        var today = timeProvider.GetLocalNow().Date;
+        var today = organizationService.TimeProvider.GetLocalNow().Date;
         var thisYear = today.Year;
         var thisMonth = today.Month;
 
@@ -431,9 +431,9 @@ public static class ConditionParser
             case ConditionOperator.InFiscalYear:
                 var fiscalYear = (int)c.Values[0];
                 c.Values.Clear();
-                var fiscalYearDate = DateTime.Parse(Environment.GetEnvironmentVariable("FiscalYearStart") ?? $"{fiscalYear}-01-01");
-                fromDate = fiscalYearDate;
-                toDate = fiscalYearDate.AddYears(1).AddDays(-1);
+                var fiscalYearDate = organizationService.Options.FiscalYearStart ?? DateOnly.Parse($"{fiscalYear}-01-01");
+                fromDate = fiscalYearDate.ToDateTime(TimeOnly.MinValue);
+                toDate = fiscalYearDate.AddYears(1).AddDays(-1).ToDateTime(TimeOnly.MinValue);
                 break;
         }
 
@@ -476,20 +476,20 @@ public static class ConditionParser
         return TranslateConditionExpressionLike(typedComputedCondition, getAttributeValueExpr, containsAttributeExpr);
     }
 
-    private static BinaryExpression TranslateConditionExpressionEqual(TimeProvider timeProvider, TypedConditionExpression c, Expression getAttributeValueExpr, Expression containsAttributeExpr)
+    private static BinaryExpression TranslateConditionExpressionEqual(FakeOrganizationService organizationService, TypedConditionExpression c, Expression getAttributeValueExpr, Expression containsAttributeExpr)
     {
         var expOrValues = Expression.Or(Expression.Constant(false), Expression.Constant(false));
 
         object? unaryOperatorValue = null;
 
-        var today = timeProvider.GetLocalNow().Date;
+        var today = organizationService.TimeProvider.GetLocalNow().Date;
         unaryOperatorValue = c.CondExpression.Operator switch
         {
             ConditionOperator.Today => today,
             ConditionOperator.Yesterday => today.AddDays(-1),
             ConditionOperator.Tomorrow => today.AddDays(1),
-            ConditionOperator.EqualUserId or ConditionOperator.NotEqualUserId => Guid.Parse(Environment.GetEnvironmentVariable("UserId") ?? Guid.Empty.ToString()),
-            ConditionOperator.EqualBusinessId or ConditionOperator.NotEqualBusinessId => Guid.Parse(Environment.GetEnvironmentVariable("BusinessUnitId") ?? Guid.Empty.ToString()),
+            ConditionOperator.EqualUserId or ConditionOperator.NotEqualUserId => organizationService.Options.UserId.ToString(),
+            ConditionOperator.EqualBusinessId or ConditionOperator.NotEqualBusinessId => organizationService.Options.BusinessUnitId.ToString(),
             _ => unaryOperatorValue
         };
 
@@ -555,8 +555,8 @@ public static class ConditionParser
     }
 
     private static BinaryExpression
-        TranslateConditionExpressionGreaterThanOrEqual(FakeOrganizationService context, TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr) =>
-        Expression.Or(TranslateConditionExpressionEqual(context.TimeProvider, tc, getAttributeValueExpr, containsAttributeExpr),
+        TranslateConditionExpressionGreaterThanOrEqual(FakeOrganizationService organizationService, TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr) =>
+        Expression.Or(TranslateConditionExpressionEqual(organizationService, tc, getAttributeValueExpr, containsAttributeExpr),
             TranslateConditionExpressionGreaterThan(tc, getAttributeValueExpr, containsAttributeExpr));
 
     private static BinaryExpression TranslateConditionExpressionGreaterThanString(TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr)
@@ -671,8 +671,8 @@ public static class ConditionParser
     }
 
     private static BinaryExpression
-        TranslateConditionExpressionLessThanOrEqual(FakeOrganizationService context, TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr) =>
-        Expression.Or(TranslateConditionExpressionEqual(context.TimeProvider, tc, getAttributeValueExpr, containsAttributeExpr),
+        TranslateConditionExpressionLessThanOrEqual(FakeOrganizationService organizationService, TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr) =>
+        Expression.Or(TranslateConditionExpressionEqual(organizationService, tc, getAttributeValueExpr, containsAttributeExpr),
             TranslateConditionExpressionLessThan(tc, getAttributeValueExpr, containsAttributeExpr));
 
     private static BinaryExpression TranslateConditionExpressionLessThanString(TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr)

--- a/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
+++ b/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
@@ -391,30 +391,30 @@ public static class ConditionParser
         {
             case ConditionOperator.ThisYear: // From first day of this year to last day of this year
                 fromDate = new DateTime(thisYear, 1, 1, 0, 0, 0, DateTimeKind.Local);
-                toDate = new DateTime(thisYear, 12, 31, 0, 0, 0, DateTimeKind.Local);
+                toDate = new DateOnly(thisYear, 12, 31).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Local);
                 break;
             case ConditionOperator.LastYear: // From first day of last year to last day of last year
                 fromDate = new DateTime(thisYear - 1, 1, 1, 0, 0, 0, DateTimeKind.Local);
-                toDate = new DateTime(thisYear - 1, 12, 31, 0, 0, 0, DateTimeKind.Local);
+                toDate = new DateOnly(thisYear - 1, 12, 31).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Local);
                 break;
             case ConditionOperator.NextYear: // From first day of next year to last day of next year
                 fromDate = new DateTime(thisYear + 1, 1, 1, 0, 0, 0, DateTimeKind.Local);
-                toDate = new DateTime(thisYear + 1, 12, 31, 0, 0, 0, DateTimeKind.Local);
+                toDate = new DateOnly(thisYear + 1, 12, 31).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Local);
                 break;
             case ConditionOperator.ThisMonth: // From first day of this month to last day of this month
                 fromDate = new DateTime(thisYear, thisMonth, 1, 0, 0, 0, DateTimeKind.Local);
                 // Last day of this month: Add one month to the first of this month, and then remove one day
-                toDate = new DateTime(thisYear, thisMonth, 1, 0, 0, 0, DateTimeKind.Local).AddMonths(1).AddDays(-1);
+                toDate = DateOnly.FromDateTime(new DateTime(thisYear, thisMonth, 1).AddMonths(1).AddDays(-1)).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Local);
                 break;
             case ConditionOperator.LastMonth: // From first day of last month to last day of last month
                 fromDate = new DateTime(thisYear, thisMonth, 1, 0, 0, 0, DateTimeKind.Local).AddMonths(-1);
                 // Last day of last month: One day before the first of this month
-                toDate = new DateTime(thisYear, thisMonth, 1, 0, 0, 0, DateTimeKind.Local).AddDays(-1);
+                toDate = DateOnly.FromDateTime(new DateTime(thisYear, thisMonth, 1).AddDays(-1)).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Local);
                 break;
             case ConditionOperator.NextMonth: // From first day of next month to last day of next month
                 fromDate = new DateTime(thisYear, thisMonth, 1, 0, 0, 0, DateTimeKind.Local).AddMonths(1);
-                // LAst day of Next Month: Add two months to the first of this month, and then go back one day
-                toDate = new DateTime(thisYear, thisMonth, 1, 0, 0, 0, DateTimeKind.Local).AddMonths(2).AddDays(-1);
+                // Last day of Next Month: Add two months to the first of this month, and then go back one day
+                toDate = DateOnly.FromDateTime(new DateTime(thisYear, thisMonth, 1).AddMonths(2).AddDays(-1)).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Local);
                 break;
             case ConditionOperator.ThisWeek:
                 fromDate = today.ToFirstDayOfDeltaWeek();
@@ -436,7 +436,7 @@ public static class ConditionParser
                     ? new DateOnly(fiscalYear, fiscalStart.Value.Month, fiscalStart.Value.Day)
                     : new DateOnly(fiscalYear, 1, 1);
                 fromDate = fiscalYearDate.ToDateTime(TimeOnly.MinValue);
-                toDate = fiscalYearDate.AddYears(1).AddDays(-1).ToDateTime(TimeOnly.MinValue);
+                toDate = fiscalYearDate.AddYears(1).AddDays(-1).ToDateTime(TimeOnly.MaxValue);
                 break;
         }
 

--- a/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
+++ b/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
@@ -431,7 +431,10 @@ public static class ConditionParser
             case ConditionOperator.InFiscalYear:
                 var fiscalYear = (int)c.Values[0];
                 c.Values.Clear();
-                var fiscalYearDate = organizationService.Options.FiscalYearStart ?? DateOnly.Parse($"{fiscalYear}-01-01");
+                var fiscalStart = organizationService.Options.FiscalYearStart;
+                var fiscalYearDate = fiscalStart.HasValue
+                    ? new DateOnly(fiscalYear, fiscalStart.Value.Month, fiscalStart.Value.Day)
+                    : new DateOnly(fiscalYear, 1, 1);
                 fromDate = fiscalYearDate.ToDateTime(TimeOnly.MinValue);
                 toDate = fiscalYearDate.AddYears(1).AddDays(-1).ToDateTime(TimeOnly.MinValue);
                 break;

--- a/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
+++ b/src/Digitall.Dataverse.Testing/Logic/Queries/ConditionParser.cs
@@ -491,8 +491,8 @@ public static class ConditionParser
             ConditionOperator.Today => today,
             ConditionOperator.Yesterday => today.AddDays(-1),
             ConditionOperator.Tomorrow => today.AddDays(1),
-            ConditionOperator.EqualUserId or ConditionOperator.NotEqualUserId => organizationService.Options.UserId.ToString(),
-            ConditionOperator.EqualBusinessId or ConditionOperator.NotEqualBusinessId => organizationService.Options.BusinessUnitId.ToString(),
+            ConditionOperator.EqualUserId or ConditionOperator.NotEqualUserId => organizationService.Options.UserId,
+            ConditionOperator.EqualBusinessId or ConditionOperator.NotEqualBusinessId => organizationService.Options.BusinessUnitId,
             _ => unaryOperatorValue
         };
 

--- a/src/Digitall.Dataverse.Testing/OrganizationRequests/RetrieveMultipleFake.cs
+++ b/src/Digitall.Dataverse.Testing/OrganizationRequests/RetrieveMultipleFake.cs
@@ -107,7 +107,7 @@ public class RetrieveMultipleFake : OrganizationRequestFake<RetrieveMultipleRequ
         }
 
         // Handle paging
-        var maxRetrieveCount = int.Parse(Environment.GetEnvironmentVariable("MaxRetrieveCount") ?? "5000");
+        var maxRetrieveCount = state.Options.MaxRetrieveCount;
         var pageSize = maxRetrieveCount;
         var pageInfo = queryExpression.PageInfo;
         var pageNumber = 1;

--- a/src/Digitall.Dataverse.Testing/OrganizationRequests/WhoAmIFake.cs
+++ b/src/Digitall.Dataverse.Testing/OrganizationRequests/WhoAmIFake.cs
@@ -10,7 +10,7 @@ public class WhoAmIFake : OrganizationRequestFake<WhoAmIRequest, WhoAmIResponse>
 {
     public override WhoAmIResponse Execute(WhoAmIRequest organizationRequest, FakeOrganizationService state)
     {
-        var userId = Guid.TryParse(Environment.GetEnvironmentVariable("UserId"), out var parsedUserId) ? parsedUserId : Guid.Empty;
+        var userId = state.Options.UserId;
 
         var results = new ParameterCollection { { "UserId", userId } };
 
@@ -18,7 +18,7 @@ public class WhoAmIFake : OrganizationRequestFake<WhoAmIRequest, WhoAmIResponse>
 
         if (user != null)
         {
-            var buId = GetBusinessUnitId(user);
+            var buId = GetBusinessUnitId(user) ?? state.Options.BusinessUnitId;
             results.Add("BusinessUnitId", buId);
 
             var orgId = GetOrganizationId(state, user, buId);
@@ -29,10 +29,10 @@ public class WhoAmIFake : OrganizationRequestFake<WhoAmIRequest, WhoAmIResponse>
         return response;
     }
 
-    private static Guid GetBusinessUnitId(Entity user)
+    private static Guid? GetBusinessUnitId(Entity user)
     {
         var buRef = user.GetAttributeValue<EntityReference>("businessunitid");
-        var buId = buRef?.Id ?? (Guid.TryParse(Environment.GetEnvironmentVariable("BusinessUnitId"), out var parsedBuId) ? parsedBuId : Guid.Empty);
+        var buId = buRef?.Id;
         return buId;
     }
 

--- a/src/Digitall.Dataverse.Testing/PluginExecutionContextBuilder.cs
+++ b/src/Digitall.Dataverse.Testing/PluginExecutionContextBuilder.cs
@@ -63,8 +63,10 @@ public class PluginExecutionContextBuilder
             if (_userId.HasValue)
                 return _userId.Value;
 
-            Guid.TryParse(Environment.GetEnvironmentVariable("UserId"), out var userId);
-            return userId;
+            if (OrganizationService is FakeOrganizationService fakeService)
+                return fakeService.Options.UserId;
+
+            return Guid.Empty;
         }
         // ReSharper disable once UnusedMember.Global : Public API
         set => _userId = value;

--- a/tests/Digitall.Dataverse.Testing.Tests/Digitall.Dataverse.Testing.Tests.csproj
+++ b/tests/Digitall.Dataverse.Testing.Tests/Digitall.Dataverse.Testing.Tests.csproj
@@ -8,8 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="TUnit" Version="1.45.22" />
-        <PackageReference Include="TUnit.Mocks" Version="1.45.22" />
-        <PackageReference Include="DotNetEnv" Version="3.2.0" />
+        <PackageReference Include="TUnit.Mocks" Version="1.45.29" />
         <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300">
           <PrivateAssets>all</PrivateAssets>

--- a/tests/Digitall.Dataverse.Testing.Tests/Digitall.Dataverse.Testing.Tests.csproj
+++ b/tests/Digitall.Dataverse.Testing.Tests/Digitall.Dataverse.Testing.Tests.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
         <PackageReference Include="TUnit" Version="1.45.22" />
         <PackageReference Include="TUnit.Mocks" Version="1.45.29" />
         <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />

--- a/tests/Digitall.Dataverse.Testing.Tests/Digitall.Dataverse.Testing.Tests.csproj
+++ b/tests/Digitall.Dataverse.Testing.Tests/Digitall.Dataverse.Testing.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
-        <PackageReference Include="TUnit" Version="1.45.22" />
+        <PackageReference Include="TUnit" Version="1.45.29" />
         <PackageReference Include="TUnit.Mocks" Version="1.45.29" />
         <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300">

--- a/tests/Digitall.Dataverse.Testing.Tests/Extensions/BuilderExtensionsTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/Extensions/BuilderExtensionsTests.cs
@@ -68,6 +68,33 @@ public class BuilderExtensionsTests
     }
 
     [Test]
+    public async Task FakeDataverseBuilderExtensions_WithMaxRetrieveCount_ShouldSetOption()
+    {
+        var builder = new FakeDataverseBuilder();
+
+        builder.WithMaxRetrieveCount(500);
+
+        var service = builder.GetOrganizationService();
+        await Assert.That(service.Options.MaxRetrieveCount).IsEqualTo(500);
+    }
+
+    [Test]
+    public async Task FakeDataverseBuilderExtensions_WithMaxRetrieveCount_Zero_ShouldThrow()
+    {
+        var builder = new FakeDataverseBuilder();
+
+        await Assert.That(() => builder.WithMaxRetrieveCount(0)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task FakeDataverseBuilderExtensions_WithMaxRetrieveCount_Negative_ShouldThrow()
+    {
+        var builder = new FakeDataverseBuilder();
+
+        await Assert.That(() => builder.WithMaxRetrieveCount(-1)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task FakeDataverseBuilderExtensions_AddConfig_ShouldAddEnvironmentVariables()
     {
         var builder = new FakeDataverseBuilder();

--- a/tests/Digitall.Dataverse.Testing.Tests/Extensions/PluginExecutionContextBuilderExtensionsTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/Extensions/PluginExecutionContextBuilderExtensionsTests.cs
@@ -230,47 +230,6 @@ public class PluginExecutionContextBuilderExtensionsTests
     }
 
     [Test]
-    public async Task WithUserId_ShouldTakePrecedenceOverEnvVariable()
-    {
-        var originalUserId = Environment.GetEnvironmentVariable("UserId");
-        var explicitUserId = Guid.NewGuid();
-        var envUserId = Guid.NewGuid();
-
-        try
-        {
-            Environment.SetEnvironmentVariable("UserId", envUserId.ToString());
-
-            var builder = new PluginExecutionContextBuilder().WithUserId(explicitUserId);
-
-            await Assert.That(builder.UserId).IsEqualTo(explicitUserId);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("UserId", originalUserId);
-        }
-    }
-
-    [Test]
-    public async Task WithUserId_ShouldNotModifyEnvironmentVariable()
-    {
-        var originalUserId = Environment.GetEnvironmentVariable("UserId");
-        var explicitUserId = Guid.NewGuid();
-
-        try
-        {
-            Environment.SetEnvironmentVariable("UserId", null);
-
-            new PluginExecutionContextBuilder().WithUserId(explicitUserId);
-
-            await Assert.That(Environment.GetEnvironmentVariable("UserId")).IsNull();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("UserId", originalUserId);
-        }
-    }
-
-    [Test]
     public async Task WithCorrelationId_ShouldSetCorrelationIdAndReturnSameBuilder()
     {
         var correlationId = Guid.NewGuid();

--- a/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
@@ -1,6 +1,7 @@
 using System.ServiceModel;
 using Digitall.Dataverse.Testing.Errors;
 using Digitall.Dataverse.Testing.Tests.Fixtures;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
@@ -242,6 +243,65 @@ public class FakeOrganizationServiceTests
     }
 
     [Test]
+    public async Task Create_SetsCreatedOnAndModifiedOn_FromTimeProvider()
+    {
+        var fakeTime = new FakeTimeProvider();
+        fakeTime.SetUtcNow(new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero));
+        var sut = new FakeOrganizationService(fakeTime);
+
+        var id = sut.Create(new Account { Name = "Test" });
+
+        var record = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(record.GetAttributeValue<DateTime>("createdon")).IsEqualTo(new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc));
+        await Assert.That(record.GetAttributeValue<DateTime>("modifiedon")).IsEqualTo(new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Test]
+    public async Task Create_SetsCreatedByAndModifiedBy_WhenUserIdIsSet()
+    {
+        var userId = Guid.NewGuid();
+        var sut = new FakeOrganizationService { Options = { UserId = userId } };
+
+        var id = sut.Create(new Account { Name = "Test" });
+
+        var record = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(record.GetAttributeValue<EntityReference>("createdby").Id).IsEqualTo(userId);
+        await Assert.That(record.GetAttributeValue<EntityReference>("modifiedby").Id).IsEqualTo(userId);
+    }
+
+    [Test]
+    public async Task Create_SetsRowVersion()
+    {
+        var sut = new FakeOrganizationService();
+
+        var id = sut.Create(new Account { Name = "Test" });
+
+        var record = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(record.RowVersion).IsNotNull();
+    }
+
+    [Test]
+    public async Task Create_DoesNotOverwriteAuditFields_WhenExplicitlyProvided()
+    {
+        var explicitTime = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var explicitUser = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var fakeTime = new FakeTimeProvider();
+        fakeTime.SetUtcNow(new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero));
+        var sut = new FakeOrganizationService(fakeTime) { Options = { UserId = userId } };
+
+        var entity = new Account { Name = "Test" };
+        entity["createdon"]  = explicitTime;
+        entity["createdby"]  = new EntityReference("systemuser", explicitUser);
+
+        var id = sut.Create(entity);
+
+        var record = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(record.GetAttributeValue<DateTime>("createdon")).IsEqualTo(explicitTime);
+        await Assert.That(record.GetAttributeValue<EntityReference>("createdby").Id).IsEqualTo(explicitUser);
+    }
+
+    [Test]
     public async Task Retrieve_EntityExists_ReturnsRecord()
     {
         var sut = new FakeOrganizationService();
@@ -372,6 +432,37 @@ public class FakeOrganizationServiceTests
 
         var retrieved = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
         await Assert.That(retrieved.ToEntity<Account>().Description).IsEquivalentTo("Updated");
+    }
+
+    [Test]
+    public async Task Update_SetsModifiedOnAndRowVersion_FromTimeProvider()
+    {
+        var fakeTime = new FakeTimeProvider();
+        fakeTime.SetUtcNow(new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var sut = new FakeOrganizationService(fakeTime);
+        var id = Guid.NewGuid();
+        sut.Add(new Account(id) { Name = "Original" });
+
+        fakeTime.SetUtcNow(new DateTimeOffset(2025, 6, 15, 10, 0, 0, TimeSpan.Zero));
+        sut.Update(new Account(id) { Name = "Updated" });
+
+        var record = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(record.GetAttributeValue<DateTime>("modifiedon")).IsEqualTo(new DateTime(2025, 6, 15, 10, 0, 0, DateTimeKind.Utc));
+        await Assert.That(record.RowVersion).IsNotNull();
+    }
+
+    [Test]
+    public async Task Update_SetsModifiedBy_WhenUserIdIsSet()
+    {
+        var userId = Guid.NewGuid();
+        var sut = new FakeOrganizationService { Options = { UserId = userId } };
+        var id = Guid.NewGuid();
+        sut.Add(new Account(id) { Name = "Original" });
+
+        sut.Update(new Account(id) { Name = "Updated" });
+
+        var record = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(record.GetAttributeValue<EntityReference>("modifiedby").Id).IsEqualTo(userId);
     }
 
     [Test]

--- a/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
@@ -344,6 +344,22 @@ public class FakeOrganizationServiceTests
     }
 
     [Test]
+    public async Task Update_MergesAttributes_PreservesExistingAttributesNotInUpdate()
+    {
+        var sut = new FakeOrganizationService();
+        var id = Guid.NewGuid();
+        sut.Add(new Account(id) { Name = "Original Name", Description = "Original Description" });
+
+        var partial = new Entity(Account.EntityLogicalName, id);
+        partial["description"] = "New Description";
+        sut.Update(partial);
+
+        var retrieved = sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(retrieved.GetAttributeValue<string>("name")).IsEqualTo("Original Name");
+        await Assert.That(retrieved.GetAttributeValue<string>("description")).IsEqualTo("New Description");
+    }
+
+    [Test]
     public async Task Update_ClonesInput_MutatingOriginalDoesNotAffectStore()
     {
         var sut = new FakeOrganizationService();

--- a/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
@@ -1,22 +1,15 @@
 using System.ServiceModel;
 using Digitall.Dataverse.Testing.Errors;
 using Digitall.Dataverse.Testing.Tests.Fixtures;
-using DotNetEnv;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 
 namespace Digitall.Dataverse.Testing.Tests;
 
 public class FakeOrganizationServiceTests
 {
-    [Before(Class)]
-    public static async Task MyClassInitialize()
-    {
-        Env.Load();
-        await Task.CompletedTask;
-    }
-
     [Test]
     public async Task ModelIsDetected()
     {
@@ -203,6 +196,49 @@ public class FakeOrganizationServiceTests
         await Assert.That(createdRecord.StateCode.Value).IsEqualTo(entity.StateCode.Value);
         await Assert.That(createdRecord.StatusCode).IsNotNull();
         await Assert.That(createdRecord.StatusCode.Value).IsEqualTo(entity.StatusCode.Value);
+    }
+
+    [Test]
+    public async Task Create_SetsOwner_WhenOwnerIsNotProvided()
+    {
+        var userId = Guid.NewGuid();
+        var entity = new Account { Name = nameof(Create_SetsOwner_WhenOwnerIsNotProvided) };
+        var sut = new FakeOrganizationService { Options = { UserId = userId } };
+
+        var result = sut.Create(entity);
+
+        var createdRecord = sut.Retrieve(Account.EntityLogicalName, result, new ColumnSet(true)).ToEntity<Account>();
+        await Assert.That(createdRecord.OwnerId).IsNotNull();
+        await Assert.That(createdRecord.OwnerId.Id).IsEqualTo(userId);
+    }
+
+    [Test]
+    public async Task Create_DoesNotOverride_WhenOwnerIsProvided()
+    {
+        var userId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var entity = new Account { Name = nameof(Create_DoesNotOverride_WhenOwnerIsProvided), OwnerId = new EntityReference("systemuser", ownerId) };
+        var sut = new FakeOrganizationService { Options = { UserId = userId } };
+
+        var result = sut.Create(entity);
+
+        var createdRecord = sut.Retrieve(Account.EntityLogicalName, result, new ColumnSet(true)).ToEntity<Account>();
+        await Assert.That(createdRecord.OwnerId.Id).IsEqualTo(ownerId);
+    }
+
+    [Test]
+    public async Task Create_DoesNotSetOwner_WhenEntityIsOrganizationOwned()
+    {
+        var userId = Guid.NewGuid();
+        var entity = new ServiceEndpoint { Name = nameof(Create_DoesNotSetOwner_WhenEntityIsOrganizationOwned) };
+
+        var sut = new FakeOrganizationService { Options = { UserId = userId } };
+        sut.AddMetadata(new EntityMetadata { LogicalName = ServiceEndpoint.EntityLogicalName, OwnershipType = OwnershipTypes.OrganizationOwned });
+
+        var result = sut.Create(entity);
+
+        var createdRecord = sut.Retrieve(ServiceEndpoint.EntityLogicalName, result, new ColumnSet(true)).ToEntity<ServiceEndpoint>();
+        await Assert.That(createdRecord.Attributes).DoesNotContain(a => a.Key == "ownerid");
     }
 
     [Test]

--- a/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/FakeOrganizationServiceTests.cs
@@ -243,6 +243,21 @@ public class FakeOrganizationServiceTests
     }
 
     [Test]
+    public async Task Create_DoesNotSetOwner_WhenProxyTypeHasNoOwnerIdAttribute()
+    {
+        // ServiceEndpoint has no OwnerId in the early-bound model.
+        // Without any metadata registered, ownerid must NOT be defaulted.
+        var userId = Guid.NewGuid();
+        var entity = new ServiceEndpoint { Name = nameof(Create_DoesNotSetOwner_WhenProxyTypeHasNoOwnerIdAttribute) };
+        var sut = new FakeOrganizationService { Options = { UserId = userId } };
+
+        var result = sut.Create(entity);
+
+        var createdRecord = sut.Retrieve(ServiceEndpoint.EntityLogicalName, result, new ColumnSet(true)).ToEntity<ServiceEndpoint>();
+        await Assert.That(createdRecord.Attributes).DoesNotContain(a => a.Key == "ownerid");
+    }
+
+    [Test]
     public async Task Create_SetsCreatedOnAndModifiedOn_FromTimeProvider()
     {
         var fakeTime = new FakeTimeProvider();

--- a/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
@@ -944,6 +944,24 @@ public class QueryTests
         await Assert.That(queryResult).IsEmpty();
     }
 
+    [Test]
+    public async Task GenerateQuery_InFiscalYear_IncludesRecordOnLastDayWithTimeComponent()
+    {
+        // Record is on the last day of fiscal year 1999 but has a non-midnight time → must still match
+        var account = new Account(Guid.NewGuid()) { OverriddenCreatedOn = new DateTime(1999, 12, 31, 23, 59, 59) };
+        var query = new QueryExpression(Account.EntityLogicalName);
+        query.Criteria.AddCondition(Account.LogicalNames.OverriddenCreatedOn, ConditionOperator.InFiscalYear, 1999);
+
+        var dataverse = new FakeOrganizationService();
+        dataverse.Add(account);
+        var sut = new ExpressionProcessor(dataverse);
+
+        var result = sut.Generate(query);
+        var queryResult = dataverse.CreateQuery<Account>().Where(result);
+
+        await Assert.That(queryResult).Count().IsEqualTo(1);
+    }
+
     #endregion
 
     #region Time Operations

--- a/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
@@ -869,6 +869,83 @@ public class QueryTests
 
     #endregion
 
+    #region InFiscalYear
+
+    [Test]
+    public async Task GenerateQuery_InFiscalYear_CalendarYear_MatchesRecordInYear()
+    {
+        // corpA has OverriddenCreatedOn = 1999-12-31 → should match fiscal year 1999 (Jan–Dec)
+        var query = new QueryExpression(Account.EntityLogicalName);
+        query.Criteria.AddCondition(Account.LogicalNames.OverriddenCreatedOn, ConditionOperator.InFiscalYear, 1999);
+
+        var dataverse = new FakeOrganizationService();
+        dataverse.AddRange(TestData.Default);
+        var sut = new ExpressionProcessor(dataverse);
+
+        var result = sut.Generate(query);
+        var queryResult = dataverse.CreateQuery<Account>().Where(result);
+
+        await Assert.That(queryResult).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GenerateQuery_InFiscalYear_CalendarYear_ExcludesRecordOutsideYear()
+    {
+        // corpB has OverriddenCreatedOn = 2000-01-02 → must NOT match fiscal year 1999
+        var query = new QueryExpression(Account.EntityLogicalName);
+        query.Criteria.AddCondition(Account.LogicalNames.OverriddenCreatedOn, ConditionOperator.InFiscalYear, 1999);
+
+        var dataverse = new FakeOrganizationService();
+        dataverse.AddRange(TestData.Default);
+        var sut = new ExpressionProcessor(dataverse);
+
+        var result = sut.Generate(query);
+        var queryResult = dataverse.CreateQuery<Account>().Where(result).ToList();
+
+        await Assert.That(queryResult.Any(a => a.Id == Guid.Parse("00000000-0000-0000-0001-000000000002"))).IsFalse();
+    }
+
+    [Test]
+    public async Task GenerateQuery_InFiscalYear_CustomStart_UsesYearFromConditionNotOption()
+    {
+        // FiscalYearStart set to 2020-04-01 (April).
+        // Fiscal year 1999 must run 1999-04-01 to 2000-03-31.
+        // corpA (1999-12-31) and corpB (2000-01-02) both fall inside that window.
+        var query = new QueryExpression(Account.EntityLogicalName);
+        query.Criteria.AddCondition(Account.LogicalNames.OverriddenCreatedOn, ConditionOperator.InFiscalYear, 1999);
+
+        var dataverse = new FakeOrganizationService();
+        dataverse.Options.FiscalYearStart = new DateOnly(2020, 4, 1);
+        dataverse.AddRange(TestData.Default);
+        var sut = new ExpressionProcessor(dataverse);
+
+        var result = sut.Generate(query);
+        var queryResult = dataverse.CreateQuery<Account>().Where(result);
+
+        await Assert.That(queryResult).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GenerateQuery_InFiscalYear_CustomStart_ExcludesRecordBeforeFiscalYearStart()
+    {
+        // FiscalYearStart = April. Fiscal year 2000 runs 2000-04-01 to 2001-03-31.
+        // Neither corpA (1999-12-31) nor corpB (2000-01-02) falls inside.
+        var query = new QueryExpression(Account.EntityLogicalName);
+        query.Criteria.AddCondition(Account.LogicalNames.OverriddenCreatedOn, ConditionOperator.InFiscalYear, 2000);
+
+        var dataverse = new FakeOrganizationService();
+        dataverse.Options.FiscalYearStart = new DateOnly(2020, 4, 1);
+        dataverse.AddRange(TestData.Default);
+        var sut = new ExpressionProcessor(dataverse);
+
+        var result = sut.Generate(query);
+        var queryResult = dataverse.CreateQuery<Account>().Where(result);
+
+        await Assert.That(queryResult).IsEmpty();
+    }
+
+    #endregion
+
     #region Time Operations
     /*
      * case ConditionOperator.OnOrAfter:

--- a/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
@@ -3,7 +3,6 @@
 
 using Digitall.Dataverse.Testing.Logic.Queries;
 using Digitall.Dataverse.Testing.Tests.Fixtures;
-using DotNetEnv;
 using Microsoft.Extensions.Time.Testing;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
@@ -12,14 +11,6 @@ namespace Digitall.Dataverse.Testing.Tests.Logic;
 
 public class QueryTests
 {
-    [Before(Class)]
-    public static async Task MyClassInitialize()
-    {
-        Environment.SetEnvironmentVariable("MaxRetrieveCount", "10");
-        Env.Load();
-        await Task.CompletedTask;
-    }
-
     #region equal
 
     [Test]
@@ -245,10 +236,9 @@ public class QueryTests
         var query = new QueryExpression(Account.EntityLogicalName);
         query.Criteria.AddCondition(Account.LogicalNames.OwningBusinessUnit, ConditionOperator.EqualBusinessId);
 
-        Environment.SetEnvironmentVariable("BusinessUnitId", TestData.BusinessUnitId.ToString("N"));
-
         var dataverse = new FakeOrganizationService(new FakeTimeProvider(new DateTime(1999, 12, 31,0,5,0, DateTimeKind.Utc).AddDays(-1)));
         dataverse.AddRange(TestData.Default);
+        dataverse.Options.BusinessUnitId = TestData.BusinessUnitId;
         var sut = new ExpressionProcessor(dataverse);
 
         var result = sut.Generate(query);
@@ -264,10 +254,9 @@ public class QueryTests
         var query = new QueryExpression(Account.EntityLogicalName);
         query.Criteria.AddCondition(Account.LogicalNames.OwnerId, ConditionOperator.EqualUserId);
 
-        Environment.SetEnvironmentVariable("UserId", TestData.UserId.ToString("N"));
-
         var dataverse = new FakeOrganizationService(new FakeTimeProvider(new DateTime(1999, 12, 31,0,5,0, DateTimeKind.Utc).AddDays(-1)));
         dataverse.AddRange(TestData.Default);
+        dataverse.Options.UserId = TestData.UserId;
         var sut = new ExpressionProcessor(dataverse);
 
         var result = sut.Generate(query);
@@ -450,10 +439,9 @@ public class QueryTests
         var query = new QueryExpression(Account.EntityLogicalName);
         query.Criteria.AddCondition(Account.LogicalNames.OwningBusinessUnit, ConditionOperator.NotEqualBusinessId);
 
-        Environment.SetEnvironmentVariable("BusinessUnitId", TestData.BusinessUnitId.ToString("N"));
-
         var dataverse = new FakeOrganizationService();
         dataverse.AddRange(TestData.Default);
+        dataverse.Options.BusinessUnitId = TestData.BusinessUnitId;
         var sut = new ExpressionProcessor(dataverse);
 
         var result = sut.Generate(query);
@@ -469,10 +457,10 @@ public class QueryTests
         var query = new QueryExpression(Account.EntityLogicalName);
         query.Criteria.AddCondition(Account.LogicalNames.OwnerId, ConditionOperator.NotEqualUserId);
 
-        Environment.SetEnvironmentVariable("UserId", TestData.UserId.ToString("N"));
-
         var dataverse = new FakeOrganizationService(new FakeTimeProvider(new DateTime(1999, 12, 31,0,5,0, DateTimeKind.Utc).AddDays(-1)));
         dataverse.AddRange(TestData.Default);
+        dataverse.Options.UserId = TestData.UserId;
+
         var sut = new ExpressionProcessor(dataverse);
 
         var result = sut.Generate(query);

--- a/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/Logic/QueryTests.cs
@@ -267,6 +267,53 @@ public class QueryTests
         await Assert.That(queryResult).Count().IsEqualTo(1);
     }
 
+    [Test]
+    public async Task GenerateQuery_EqualUserId_LateBound_MatchesRecord()
+    {
+        var userId = Guid.NewGuid();
+        var id = Guid.NewGuid();
+
+        // Use a custom entity with no proxy type: AttributeType will be null (truly late-bound)
+        var entity = new Entity("custom_entity", id);
+        entity["ownerid"] = new EntityReference("systemuser", userId);
+
+        var query = new QueryExpression("custom_entity");
+        query.Criteria.AddCondition("ownerid", ConditionOperator.EqualUserId);
+
+        var dataverse = new FakeOrganizationService();
+        dataverse.Add(entity);
+        dataverse.Options.UserId = userId;
+        var sut = new ExpressionProcessor(dataverse);
+
+        var result = sut.Generate(query);
+        var queryResult = dataverse.CreateQuery<Entity>("custom_entity").Where(result).ToList();
+
+        await Assert.That(queryResult).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GenerateQuery_EqualBusinessId_LateBound_MatchesRecord()
+    {
+        var businessUnitId = Guid.NewGuid();
+        var id = Guid.NewGuid();
+
+        var entity = new Entity("custom_entity", id);
+        entity["owningbusinessunit"] = new EntityReference("businessunit", businessUnitId);
+
+        var query = new QueryExpression("custom_entity");
+        query.Criteria.AddCondition("owningbusinessunit", ConditionOperator.EqualBusinessId);
+
+        var dataverse = new FakeOrganizationService();
+        dataverse.Add(entity);
+        dataverse.Options.BusinessUnitId = businessUnitId;
+        var sut = new ExpressionProcessor(dataverse);
+
+        var result = sut.Generate(query);
+        var queryResult = dataverse.CreateQuery<Entity>("custom_entity").Where(result).ToList();
+
+        await Assert.That(queryResult).Count().IsEqualTo(1);
+    }
+
     #endregion
 
     #region not equal

--- a/tests/Digitall.Dataverse.Testing.Tests/OrganizationRequests/OrganizationRequestFakeTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/OrganizationRequests/OrganizationRequestFakeTests.cs
@@ -186,6 +186,28 @@ public class OrganizationRequestFakeTests
     }
 
     [Test]
+    public async Task AssignRequestFake_Should_PreserveExistingAttributes()
+    {
+        _sut.AddRequest(new AssignRequestFake());
+        var id = Guid.NewGuid();
+        _sut.Add(new Account(id) { Name = "My Account", Description = "Some Description" });
+        var userId = Guid.NewGuid();
+        var userRef = new EntityReference("systemuser", userId);
+
+        var request = new AssignRequest
+        {
+            Target = new EntityReference(Account.EntityLogicalName, id),
+            Assignee = userRef
+        };
+
+        _sut.Execute(request);
+
+        var updated = _sut.Retrieve(Account.EntityLogicalName, id, new ColumnSet(true));
+        await Assert.That(updated.GetAttributeValue<string>("name")).IsEqualTo("My Account");
+        await Assert.That(updated.GetAttributeValue<string>("description")).IsEqualTo("Some Description");
+    }
+
+    [Test]
     public async Task AssociateFake_Should_CallStateAssociate()
     {
         _sut.AddRequest(new AssociateFake());

--- a/tests/Digitall.Dataverse.Testing.Tests/OrganizationRequests/RetrieveMultipleTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/OrganizationRequests/RetrieveMultipleTests.cs
@@ -2,7 +2,6 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using Digitall.Dataverse.Testing.Tests.Fixtures;
-using DotNetEnv;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 
@@ -10,14 +9,6 @@ namespace Digitall.Dataverse.Testing.Tests.OrganizationRequests;
 
 public class RetrieveMultipleTests
 {
-    [Before(Class)]
-    public static async Task MyClassInitialize()
-    {
-        Environment.SetEnvironmentVariable("MaxRetrieveCount", "10");
-        Env.Load();
-        await Task.CompletedTask;
-    }
-
     [Test]
     public async Task Stubs_Dispatch_Working()
     {
@@ -48,7 +39,7 @@ public class RetrieveMultipleTests
     [Test]
     public async Task QueryExpression_Paging()
     {
-        var sut = new FakeOrganizationService();
+        var sut = new FakeOrganizationService{ Options = { MaxRetrieveCount = 10 }};
 
         var manyRecords = new List<Account>();
         Enumerable.Range(0, 19).ToList().ForEach(x => manyRecords.Add(new Account(Guid.NewGuid()){Name = $"Account {x}"}));
@@ -78,7 +69,7 @@ public class RetrieveMultipleTests
     [Test]
     public async Task QueryExpression_EmptyPageOnPaging()
     {
-        var sut = new FakeOrganizationService();
+        var sut = new FakeOrganizationService{ Options = { MaxRetrieveCount = 10 }};
 
         var manyRecords = new List<Account>();
         Enumerable.Range(0, 200).ToList().ForEach(x => manyRecords.Add(new Account(Guid.NewGuid()){Name = $"Account {x}"}));
@@ -220,7 +211,7 @@ public class RetrieveMultipleTests
     [Test]
     public async Task QueryByAttribute_Paging()
     {
-        var sut = new FakeOrganizationService();
+        var sut = new FakeOrganizationService{  Options = { MaxRetrieveCount = 10 }};
 
         var manyRecords = new List<Account>();
         Enumerable.Range(0, 19).ToList().ForEach(x => manyRecords.Add(new Account(Guid.NewGuid()){Name = $"Account {x}"}));
@@ -250,7 +241,7 @@ public class RetrieveMultipleTests
     [Test]
     public async Task QueryByAttribute_EmptyPageOnPaging()
     {
-        var sut = new FakeOrganizationService();
+        var sut = new FakeOrganizationService { Options = { MaxRetrieveCount = 10 } };
 
         var manyRecords = new List<Account>();
         Enumerable.Range(0, 200).ToList().ForEach(x => manyRecords.Add(new Account(Guid.NewGuid()){Name = $"Account {x}"}));

--- a/tests/Digitall.Dataverse.Testing.Tests/OrganizationRequests/WhoAmITests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/OrganizationRequests/WhoAmITests.cs
@@ -2,20 +2,12 @@
 // DIGITALL Nature licenses this file to you under the Microsoft Public License.
 
 using Digitall.Dataverse.Testing.OrganizationRequests;
-using DotNetEnv;
 using Microsoft.Crm.Sdk.Messages;
 
 namespace Digitall.Dataverse.Testing.Tests.OrganizationRequests;
 
 public class WhoAmITests
 {
-    [Before(Class)]
-    public static async Task MyClassInitialize()
-    {
-        Env.Load();
-        await Task.CompletedTask;
-    }
-
     [Test]
     public async Task Stubs_Dispatch_Working()
     {

--- a/tests/Digitall.Dataverse.Testing.Tests/PluginExecutionContextBuilderTests.cs
+++ b/tests/Digitall.Dataverse.Testing.Tests/PluginExecutionContextBuilderTests.cs
@@ -58,9 +58,7 @@ public class PluginExecutionContextBuilderTests
     {
         var entity = new Entity("unittest", Guid.NewGuid());
 
-        var serviceProvider = new FakePluginContextBuilder()
-            .AddData(entity)
-            .BuildServiceProvider();
+        var serviceProvider = new FakePluginContextBuilder().AddData(entity).BuildServiceProvider();
 
         var organizationServiceFactory = serviceProvider.GetService(typeof(IOrganizationServiceFactory)) as IOrganizationServiceFactory;
         await Assert.That(organizationServiceFactory).IsNotNull();
@@ -77,9 +75,7 @@ public class PluginExecutionContextBuilderTests
     public async Task SettingEntityTarget_Should_SetInputParameter_And_PluginPrimaryEntity()
     {
         var target = new Entity("unittest", Guid.NewGuid());
-        var serviceProvider = new PluginExecutionContextBuilder()
-            .WithTarget(target)
-            .BuildServiceProvider();
+        var serviceProvider = new PluginExecutionContextBuilder().WithTarget(target).BuildServiceProvider();
 
         var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
         await Assert.That(pluginContext).IsNotNull();
@@ -96,9 +92,7 @@ public class PluginExecutionContextBuilderTests
     public async Task SettingTargetReference_Should_SetInputParameter_And_PluginPrimaryEntity()
     {
         var target = new EntityReference("unittest", Guid.NewGuid());
-        var serviceProvider = new PluginExecutionContextBuilder()
-            .WithTarget(target)
-            .BuildServiceProvider();
+        var serviceProvider = new PluginExecutionContextBuilder().WithTarget(target).BuildServiceProvider();
 
         var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
         await Assert.That(pluginContext).IsNotNull();
@@ -118,9 +112,7 @@ public class PluginExecutionContextBuilderTests
     [Arguments("custom")]
     public async Task SettingRequestType_Should_SetPluginMessageName(string messageName)
     {
-        var serviceProvider = new PluginExecutionContextBuilder()
-            .WithMessageName(messageName)
-            .BuildServiceProvider();
+        var serviceProvider = new PluginExecutionContextBuilder().WithMessageName(messageName).BuildServiceProvider();
 
         var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
         await Assert.That(pluginContext).IsNotNull();
@@ -131,8 +123,7 @@ public class PluginExecutionContextBuilderTests
     public async Task SettingTracingService_Should_OverwriteDefault()
     {
         var tracingService = Mock.Of<ITracingService>();
-        var serviceProvider = new PluginExecutionContextBuilder((ITracingService)tracingService)
-            .BuildServiceProvider();
+        var serviceProvider = new PluginExecutionContextBuilder((ITracingService)tracingService).BuildServiceProvider();
 
         var tracingServiceFromContext = serviceProvider.GetService(typeof(ITracingService));
         await Assert.That(tracingServiceFromContext).IsNotNull();
@@ -165,8 +156,7 @@ public class PluginExecutionContextBuilderTests
     public Task TestPlugin_Durchstich()
     {
         var tracingServiceMock = Mock.Of<ITracingService>();
-        var serviceProvider = new PluginExecutionContextBuilder((ITracingService)tracingServiceMock)
-            .BuildServiceProvider();
+        var serviceProvider = new PluginExecutionContextBuilder((ITracingService)tracingServiceMock).BuildServiceProvider();
 
         var plugin = new TestPlugin();
         plugin.Execute(serviceProvider);
@@ -181,15 +171,8 @@ public class PluginExecutionContextBuilderTests
         var initiatingUserId = Guid.NewGuid();
         var correlationId = Guid.NewGuid();
 
-        var serviceProvider = new PluginExecutionContextBuilder
-        {
-            Mode = 1,
-            Stage = 40
-        }
-        .WithInitiatingUserId(initiatingUserId)
-        .WithCorrelationId(correlationId)
-        .WithMessageName(SdkMessageNames.Update)
-        .BuildServiceProvider();
+        var serviceProvider = new PluginExecutionContextBuilder { Mode = 1, Stage = 40 }.WithInitiatingUserId(initiatingUserId).WithCorrelationId(correlationId).WithMessageName(SdkMessageNames.Update)
+            .BuildServiceProvider();
 
         var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
 
@@ -210,13 +193,8 @@ public class PluginExecutionContextBuilderTests
         var preImages = new EntityImageCollection { ["Pre"] = new Entity("account", Guid.NewGuid()) };
         var postImages = new EntityImageCollection { ["Post"] = new Entity("account", Guid.NewGuid()) };
 
-        var serviceProvider = new PluginExecutionContextBuilder()
-            .WithInputParameters(input)
-            .WithOutputParameters(output)
-            .WithSharedVariables(shared)
-            .WithPreEntityImages(preImages)
-            .WithPostEntityImages(postImages)
-            .BuildServiceProvider();
+        var serviceProvider = new PluginExecutionContextBuilder().WithInputParameters(input).WithOutputParameters(output).WithSharedVariables(shared).WithPreEntityImages(preImages)
+            .WithPostEntityImages(postImages).BuildServiceProvider();
 
         var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
         var pluginContext7 = serviceProvider.GetService(typeof(IPluginExecutionContext7)) as IPluginExecutionContext7;
@@ -260,10 +238,8 @@ public class PluginExecutionContextBuilderTests
     [Test]
     public Task ExistingTargetParameter_Should_ThrowOnBuild_WhenTargetIsAlsoConfigured()
     {
-        void Action() => new PluginExecutionContextBuilder()
-            .WithInputParameter("Target", new Entity("contact", Guid.NewGuid()))
-            .WithTarget(new Entity("account", Guid.NewGuid()))
-            .BuildServiceProvider();
+        void Action() =>
+            new PluginExecutionContextBuilder().WithInputParameter("Target", new Entity("contact", Guid.NewGuid())).WithTarget(new Entity("account", Guid.NewGuid())).BuildServiceProvider();
 
         Assert.Throws<ArgumentException>(Action);
         return Task.CompletedTask;
@@ -298,45 +274,24 @@ public class PluginExecutionContextBuilderTests
     }
 
     [Test]
-    public async Task UserId_WhenEnvVariableSet_Should_BeUsedAsDefault()
+    public async Task UserId_WhenSet_Should_BeUsedAsDefault()
     {
-        var originalUserId = Environment.GetEnvironmentVariable("UserId");
-        var envUserId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
 
-        try
-        {
-            Environment.SetEnvironmentVariable("UserId", envUserId.ToString());
+        var serviceProvider = new PluginExecutionContextBuilder().WithUserId(userId).BuildServiceProvider();
+        var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
 
-            var serviceProvider = new PluginExecutionContextBuilder().BuildServiceProvider();
-            var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
-
-            await Assert.That(pluginContext).IsNotNull();
-            await Assert.That(pluginContext!.UserId).IsEqualTo(envUserId);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("UserId", originalUserId);
-        }
+        await Assert.That(pluginContext).IsNotNull();
+        await Assert.That(pluginContext!.UserId).IsEqualTo(userId);
     }
 
     [Test]
-    public async Task InvalidUserIdEnvVar_Should_DefaultToEmptyGuid()
+    public async Task UserId_Should_DefaultToEmptyGuid()
     {
-        var originalUserId = Environment.GetEnvironmentVariable("UserId");
+        var serviceProvider = new PluginExecutionContextBuilder().BuildServiceProvider();
+        var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
 
-        try
-        {
-            Environment.SetEnvironmentVariable("UserId", "invalid-guid");
-
-            var serviceProvider = new PluginExecutionContextBuilder().BuildServiceProvider();
-            var pluginContext = serviceProvider.GetService(typeof(IPluginExecutionContext)) as IPluginExecutionContext;
-
-            await Assert.That(pluginContext).IsNotNull();
-            await Assert.That(pluginContext!.UserId).IsEqualTo(Guid.Empty);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("UserId", originalUserId);
-        }
+        await Assert.That(pluginContext).IsNotNull();
+        await Assert.That(pluginContext!.UserId).IsEqualTo(Guid.Empty);
     }
 }

--- a/tests/Digitall.Dataverse.Testing.Tests/packages.lock.json
+++ b/tests/Digitall.Dataverse.Testing.Tests/packages.lock.json
@@ -51,15 +51,15 @@
       },
       "TUnit": {
         "type": "Direct",
-        "requested": "[1.45.22, )",
-        "resolved": "1.45.22",
-        "contentHash": "sp/fSGviOO5iSjkgqUoTVqYqaiRuWnqFwvIfTrHln8TaQxIZUM2jAzluP+6l9gq/pZmU96eTCjSyArEnOkXjmw==",
+        "requested": "[1.45.29, )",
+        "resolved": "1.45.29",
+        "contentHash": "pWscjrBi/2U1WkMr4eWYtLqo5KlgGGaUNu853BwOyy5cOE75pDrtFXhvUOdrfcfHsOopM+26VMOxhKVV54ZD9w==",
         "dependencies": {
           "Microsoft.Testing.Extensions.CodeCoverage": "18.7.0",
           "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
           "Microsoft.Testing.Extensions.TrxReport": "2.2.3",
-          "TUnit.Assertions": "1.45.22",
-          "TUnit.Engine": "1.45.22"
+          "TUnit.Assertions": "1.45.29",
+          "TUnit.Engine": "1.45.29"
         }
       },
       "TUnit.Mocks": {
@@ -373,24 +373,24 @@
       },
       "TUnit.Assertions": {
         "type": "Transitive",
-        "resolved": "1.45.22",
-        "contentHash": "tUFBQ9q+9Rife2TJOWINbgTPmOMbMfm0M3R976s/UZpkohqQl64pKXSlP5ZghAR49cXCjiue0ycDqkRc6td7JA=="
+        "resolved": "1.45.29",
+        "contentHash": "juiqf1GXOicdt51ZSOW5XCee/4bt9visfbSK8ABNhd3oehal7MuxKCAYnyZinCiLOeG/91A4v5+HD0EZsvGDyQ=="
       },
       "TUnit.Core": {
         "type": "Transitive",
-        "resolved": "1.45.22",
-        "contentHash": "Ee3UgUa/UVOErcspTDyeOD+iWgH4DDzLf9IMPeVfNSM+vJ1trrWh3DYE3SUgU5cM1KkoZTlU5LT12rUYSXmy7A=="
+        "resolved": "1.45.29",
+        "contentHash": "w5G6uIH/o8AvZyuJ8d4+D6qWD7E5QBIhhA86I7qzX8nOm7QolIbQvKxacZt+2DaCusyr/io5D5gFgwGef1Ud2A=="
       },
       "TUnit.Engine": {
         "type": "Transitive",
-        "resolved": "1.45.22",
-        "contentHash": "oTdRcTcQHKwWRnhpAHX0DsrxsIX0sAoRqrCBuhICU7e03WpYnSNM00czzFPbgikHfm4HP81SzUbnG1BrdRTFLQ==",
+        "resolved": "1.45.29",
+        "contentHash": "linCf8Zk5Hb6S+GbzAXPJJ13b8euncSEKKUdLrAMWLnlGdHvhFcWDtAEMJXN7kNdiliPaFCzWC0D2mysNJ14VQ==",
         "dependencies": {
           "EnumerableAsyncProcessor": "3.8.4",
           "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
           "Microsoft.Testing.Platform": "2.2.3",
           "Microsoft.Testing.Platform.MSBuild": "2.2.3",
-          "TUnit.Core": "1.45.22"
+          "TUnit.Core": "1.45.29"
         }
       },
       "digitall.dataverse.testing": {

--- a/tests/Digitall.Dataverse.Testing.Tests/packages.lock.json
+++ b/tests/Digitall.Dataverse.Testing.Tests/packages.lock.json
@@ -2,17 +2,6 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
-      "DotNetEnv": {
-        "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "2q+PD+aJcRW9QuRcIv4F8WbvEDxI6cwxzZJec2i45cBY4cAKCAoW4ZPkApJ7H82wr6Yfmxx/0kb1nLnRmZrGZA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "1.1.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "1.1.2",
-          "Superpower": "3.0.0"
-        }
-      },
       "Microsoft.PowerPlatform.Dataverse.Client": {
         "type": "Direct",
         "requested": "[1.2.10, )",
@@ -69,9 +58,9 @@
       },
       "TUnit.Mocks": {
         "type": "Direct",
-        "requested": "[1.45.22, )",
-        "resolved": "1.45.22",
-        "contentHash": "uWtP+VSBehJZiRDZjma7nwSSUck71etVUi48JyLZDPEllrKGec4WhnkIjdM2b4W0AhaIbFOz/SFRml1VCj+38w=="
+        "requested": "[1.45.29, )",
+        "resolved": "1.45.29",
+        "contentHash": "nO7ncab70585Bs8elf/Mzn53oKT5s58focRPI9193ns0wr4Psmb9uNwMijVIjFa7mUaoex5Srp0Qfa8kOyjuEQ=="
       },
       "EnumerableAsyncProcessor": {
         "type": "Transitive",
@@ -302,11 +291,6 @@
         "type": "Transitive",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "Superpower": {
-        "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "bjKbAYWePooCAvPxQq+3KnmcLfRggMyRoXmtBMlmCG71bdwBHrO6rmRJ2DRIodg5aztNcxeZXBUVWT+H+MZUhw=="
       },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",

--- a/tests/Digitall.Dataverse.Testing.Tests/packages.lock.json
+++ b/tests/Digitall.Dataverse.Testing.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.6.0, )",
+        "resolved": "10.6.0",
+        "contentHash": "qQDiaYWpvIymGbu+kXaMDS8YdqfeQkv6DOxPF2GSwC+eSzIKqOOnSP34TYt7gKqvB7p8/aSptexnW6nF0CUdnw=="
+      },
       "Microsoft.PowerPlatform.Dataverse.Client": {
         "type": "Direct",
         "requested": "[1.2.10, )",
@@ -200,11 +206,6 @@
         "type": "Transitive",
         "resolved": "3.1.8",
         "contentHash": "XcIoXQhT0kwnEhOKv/LmpWR6yF6QWmBTy9Fcsz4aHuCOgTJ7Zd23ELtUA4BfwlYoFlSedavS+vURz9tNekd44g=="
-      },
-      "Microsoft.Extensions.TimeProvider.Testing": {
-        "type": "Transitive",
-        "resolved": "10.6.0",
-        "contentHash": "qQDiaYWpvIymGbu+kXaMDS8YdqfeQkv6DOxPF2GSwC+eSzIKqOOnSP34TYt7gKqvB7p8/aSptexnW6nF0CUdnw=="
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",


### PR DESCRIPTION
feat: set ownerid on record create for non organization owned entities (if not provided)
BREAKING CHANGE: remove configuration via environment variables because these cause flakiness when tests are executed in parallel